### PR TITLE
Use seedrandom to make rng seedable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Avatar Generator
 
 - Generates random avatars from the website https://getavataaars.com/
+
+## Usage
+
+```typescript
+import { AvatarGenerator } from 'seedable-random-avatar-generator';
+
+const generator = new AvatarGenerator();
+
+// Simply get a random avatar
+generator.generateRandomAvatar();
+
+// Optionally specify a seed for the avatar. e.g. for always getting the same avatar for a user id.
+// With seed 'avatar', always returns https://avataaars.io/?accessoriesType=Kurt&avatarStyle=Circle&clotheColor=Blue01&clotheType=Hoodie&eyeType=EyeRoll&eyebrowType=RaisedExcitedNatural&facialHairColor=Blonde&facialHairType=BeardMagestic&hairColor=Black&hatColor=White&mouthType=Sad&skinColor=Yellow&topType=ShortHairShortWaved
+generator.generateRandomAvatar('avatar'); 
+
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "random-avatar-generator",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/seedrandom": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-2.4.28.tgz",
+      "integrity": "sha512-SMA+fUwULwK7sd/ZJicUztiPs8F1yCPwF3O23Z9uQ32ME5Ha0NmDK9+QTsYE4O2tHXChzXomSWWeIhCnoN1LqA=="
+    },
+    "seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,5 +17,9 @@
     "avatar",
     "random",
     "generator"
-  ]
+  ],
+  "dependencies": {
+    "@types/seedrandom": "^2.4.28",
+    "seedrandom": "^3.0.5"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import seedrandom from 'seedrandom';
+
 /** @description Class to generate avatars  */
 export class AvatarGenerator {
   constructor() {}
@@ -5,7 +7,7 @@ export class AvatarGenerator {
   /** @description Generates random avatar image URL
    * @returns Random avatar image URL
    */
-  generateRandomAvatar() {
+  generateRandomAvatar(seed?: string) {
     let topTypeOptions = new Array<string>();
     topTypeOptions.push(
       "NoHair",
@@ -202,36 +204,39 @@ export class AvatarGenerator {
       "White"
     );
 
+    const rng = seed ? seedrandom(seed) : seedrandom();
+
     return `https://avataaars.io/?accessoriesType=${
       accessoriesTypeOptions[
-        Math.floor(Math.random() * accessoriesTypeOptions.length)
+        Math.floor(rng() * accessoriesTypeOptions.length)
       ]
     }&avatarStyle=Circle&clotheColor=${
-      clotheColorOptions[Math.floor(Math.random() * clotheColorOptions.length)]
+      clotheColorOptions[Math.floor(rng() * clotheColorOptions.length)]
     }&clotheType=${
-      clotheTypeOptions[Math.floor(Math.random() * clotheTypeOptions.length)]
+      clotheTypeOptions[Math.floor(rng() * clotheTypeOptions.length)]
     }&eyeType=${
-      eyeTypeOptions[Math.floor(Math.random() * eyeTypeOptions.length)]
+      eyeTypeOptions[Math.floor(rng() * eyeTypeOptions.length)]
     }&eyebrowType=${
-      eyebrowTypeOptions[Math.floor(Math.random() * eyebrowTypeOptions.length)]
+      eyebrowTypeOptions[Math.floor(rng() * eyebrowTypeOptions.length)]
     }&facialHairColor=${
       facialHairColorOptions[
-        Math.floor(Math.random() * facialHairColorOptions.length)
+        Math.floor(rng() * facialHairColorOptions.length)
       ]
     }&facialHairType=${
       facialHairTypeOptions[
-        Math.floor(Math.random() * facialHairTypeOptions.length)
+        Math.floor(rng() * facialHairTypeOptions.length)
       ]
     }&hairColor=${
-      hairColorTypes[Math.floor(Math.random() * hairColorTypes.length)]
+      hairColorTypes[Math.floor(rng() * hairColorTypes.length)]
     }&hatColor=${
-      hatColorOptions[Math.floor(Math.random() * hatColorOptions.length)]
+      hatColorOptions[Math.floor(rng() * hatColorOptions.length)]
     }&mouthType=${
-      mouthTypeOptions[Math.floor(Math.random() * mouthTypeOptions.length)]
+      mouthTypeOptions[Math.floor(rng() * mouthTypeOptions.length)]
     }&skinColor=${
-      skinColorOptions[Math.floor(Math.random() * skinColorOptions.length)]
+      skinColorOptions[Math.floor(rng() * skinColorOptions.length)]
     }&topType=${
-      topTypeOptions[Math.floor(Math.random() * topTypeOptions.length)]
+      topTypeOptions[Math.floor(rng() * topTypeOptions.length)]
     }`;
   }
 }
+


### PR DESCRIPTION
- Added optional parameter seed, the same avatar is always returned for
  a given seed.
- Without specifying seed, avatar generation stays random.
- Example usage (my use case): Get the same avatar every time for a given user id.